### PR TITLE
Feat:개인런 조회, 라우터 수정

### DIFF
--- a/src/running/controllers/running.controller.ts
+++ b/src/running/controllers/running.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   Param,
   Patch,
   Post,
@@ -16,12 +17,12 @@ import {
 } from '../dto/single-running.dto';
 import { SingleRunningService } from '../services/single-running.service';
 
-@Controller('single-running')
-export class SingleRunningController {
+@Controller('running')
+export class RunningController {
   constructor(private readonly singleRunningService: SingleRunningService) {}
 
   @UseGuards(JwtAccessAuthGuard)
-  @Post()
+  @Post('single')
   runStart(
     @User() user: DeserializeAccessToken,
     @Body() body: SingleRunningStartRequest,
@@ -30,7 +31,7 @@ export class SingleRunningController {
   }
 
   @UseGuards(JwtAccessAuthGuard)
-  @Post('running')
+  @Post()
   running(@Body() body: RunningRequest): Promise<SingleRunningResponse> {
     return this.singleRunningService.running(body);
   }
@@ -39,5 +40,19 @@ export class SingleRunningController {
   @Patch(':id')
   runEnd(@Param('id') id: string): Promise<SingleRunningResponse> {
     return this.singleRunningService.runEnd(id);
+  }
+
+  @UseGuards(JwtAccessAuthGuard)
+  @Get('list')
+  getList(
+    @User() user: DeserializeAccessToken,
+  ): Promise<SingleRunningResponse[]> {
+    return this.singleRunningService.getList(user);
+  }
+
+  @UseGuards(JwtAccessAuthGuard)
+  @Get(':id')
+  getRunning(@Param('id') id: string): Promise<SingleRunningResponse> {
+    return this.singleRunningService.getRunning(id);
   }
 }

--- a/src/running/running.module.ts
+++ b/src/running/running.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
-import { SingleRunningController } from './controllers/single-running.controller';
+import { RunningController } from './controllers/running.controller';
 import { RunningRespository } from './running.repository';
 import { Runnings, RunningSchema } from './schemas/running.schema';
 import { SingleRunningService } from './services/single-running.service';
@@ -9,7 +9,7 @@ import { SingleRunningService } from './services/single-running.service';
   imports: [
     MongooseModule.forFeature([{ name: Runnings.name, schema: RunningSchema }]),
   ],
-  controllers: [SingleRunningController],
+  controllers: [RunningController],
   providers: [SingleRunningService, RunningRespository],
 })
 export class RunningModule {}

--- a/src/running/running.repository.ts
+++ b/src/running/running.repository.ts
@@ -29,6 +29,12 @@ export class RunningRespository {
     return await this.runningModel.findOne().where({ _id: id });
   }
 
+  async findByUser(user: DeserializeAccessToken): Promise<Runnings[]> {
+    return await this.runningModel.find().where({
+      user,
+    });
+  }
+
   async updateOneRunning({
     id,
     runDistance,
@@ -48,6 +54,7 @@ export class RunningRespository {
           },
         },
       },
+      { new: true },
     );
   }
 
@@ -59,6 +66,7 @@ export class RunningRespository {
           runTime,
         },
       },
+      { new: true },
     );
   }
 }

--- a/src/running/services/single-running.service.ts
+++ b/src/running/services/single-running.service.ts
@@ -120,4 +120,35 @@ export class SingleRunningService {
       throw new BadRequestException('BadRequest');
     }
   }
+
+  async getRunning(id: string): Promise<SingleRunningResponse> {
+    try {
+      const findRunning = await this.runningRepository.findById(id);
+      if (!findRunning) {
+        throw new HttpException('러닝이 존재하지 않습니다', 400);
+      }
+
+      return findRunning.responseData;
+    } catch (err) {
+      console.error(err);
+      throw new BadRequestException('BadRequest');
+    }
+  }
+
+  async getList(
+    user: DeserializeAccessToken,
+  ): Promise<SingleRunningResponse[]> {
+    try {
+      const findRunning = await this.runningRepository.findByUser(user);
+
+      if (!findRunning) {
+        throw new HttpException('러닝이 존재하지 않습니다', 400);
+      }
+
+      return findRunning.map((running) => running.responseData);
+    } catch (err) {
+      console.error(err);
+      throw new BadRequestException('BadRequest');
+    }
+  }
 }


### PR DESCRIPTION
## Main Development
- 개인런 조회 기능
- 라우터 수정

## 작업사항

### 개인런 조회 기능
- 개인런 id로 개인런 정보 조회 기능
- 유저 token의 값으로 유저의 전체 개인 러닝 조회 기능
### 라우터 수정
- 기존 `single-running`의 라우터를 `running` 으로 수정
- 러닝 시작 `POST /running/single`
- 러닝 데이터 전송 `POST /running`
- 러닝 종료 `PATCH /running/:id`
- 러닝 1개 조회 `GET /running/:id`
- 유저 러닝 리스트 조회 `GET /running/list`

## 추가사항[Optional]
- 모여런의 개발에 따른 개인런 라우터 네이밍 수정될 수 있음.
- 유저의 러닝 정보 전체 조회시, 기획적인 부분에서 수정될 사항이 있어서 그냥 단순 user 정보로만 찾고 추가 조건은 안줬습니다.

Closes #15 
